### PR TITLE
Add build step to the usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,6 @@ describe('App', () => {
 Running:
 
 ```
+docker-compose -f docker-compose.integration-tests.yml build --pull
 docker-compose -f integration-tests run tests
 ```


### PR DESCRIPTION
Add the docker-compose build command in to the usage example so it's quicker for users to get up and running.
