### PR TITLE
Fix tests app name

### DIFF
--- a/example/docker-compose.integration-tests.yml
+++ b/example/docker-compose.integration-tests.yml
@@ -7,10 +7,10 @@ services:
     volumes:
       - "./integration-tests:/integration-tests"
       - "./screenshots:/screenshots"
-    command: "wait-for-it.sh app:80 -- mocha --recursive /integration-tests"
+    command: "wait-for-it.sh web:80 -- mocha --recursive /integration-tests"
     links:
-      - app
-  app:
+      - web
+  web:
     image: tutum/hello-world
     expose:
       - "80"

--- a/example/integration-tests/index.test.js
+++ b/example/integration-tests/index.test.js
@@ -34,7 +34,7 @@ after(async() => {
 
 describe('App', () => {
   it('renders', async() => {
-    const response = await page.goto('http://app/')
+    const response = await page.goto('http://web/')
     assert(response.ok())
     await page.screenshot({ path: `/screenshots/app.png` })
   })


### PR DESCRIPTION
docker-compose version 1.23.2, build 1110ad01
Docker version 18.09.0, build 4d60db4

Run example tests fails
```
wait-for-it.sh: waiting 15 seconds for app:80
wait-for-it.sh: app:80 is available after 0 seconds


Started HeadlessChrome/75.0.3738.0
  App
    1) renders


  0 passing (268ms)
  1 failing

  1) App
       renders:
     Error: net::ERR_CONNECTION_REFUSED at http://app/
      at navigate (/node_modules/puppeteer/lib/FrameManager.js:101:37)
      at process._tickCallback (internal/process/next_tick.js:68:7)
    -- ASYNC --
      at Frame.<anonymous> (/node_modules/puppeteer/lib/helper.js:110:27)
      at Page.goto (/node_modules/puppeteer/lib/Page.js:656:49)
      at Page.<anonymous> (/node_modules/puppeteer/lib/helper.js:111:23)
      at Context.it (/integration-tests/index.test.js:37:33)
```

For some reasons chrome can't work with `http://app`. Possibly it is reserved name


A small renaming solves the issue


