### PR TITLE
Manual installation of libgconf-2-4 is not required anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@
 FROM node:10.15.3-slim@sha256:88da5cd281ece24309c4e6fcce000a8001b17804e19f94a0439954568716a668
     
 RUN  apt-get update \
-     # See https://crbug.com/795759
-     && apt-get install -yq libgconf-2-4 \
      # Install latest chrome dev package, which installs the necessary libs to
      # make the bundled version of Chromium that Puppeteer installs work.
      && apt-get install -y wget --no-install-recommends \


### PR DESCRIPTION
The issue was fixed
https://bugs.chromium.org/p/chromium/issues/detail?id=795759#c7