### PR TITLE
Fixed libxss issue for non-updated puppeteer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 FROM node:12.18.3-buster-slim@sha256:dd6aa3ed10af4374b88f8a6624aeee7522772bb08e8dd5e917ff729d1d3c3a4f
     
 RUN  apt-get update \
-     && apt-get install -y wget gnupg ca-certificates \
+     && apt-get install -y wget gnupg ca-certificates libxss1 \
      && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
      && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
      && apt-get update \


### PR DESCRIPTION
Fix the issue when the stable version of Chrome doesn't cover all Puppeteer dependencies