### PR TITLE
[Docker] Multiple Node.js versions build

### DIFF
--- a/.github/workflows/docker-commit.yml
+++ b/.github/workflows/docker-commit.yml
@@ -19,6 +19,10 @@ jobs:
     strategy:
       matrix:
         node:
+          - 12.22-buster
+          - 12.22-buster-slim
+          - 12.22-stretch
+          - 12.22-stretch-slim
           - 14.16-buster
           - 14.16-buster-slim
           - 14.16-stretch

--- a/.github/workflows/docker-commit.yml
+++ b/.github/workflows/docker-commit.yml
@@ -1,0 +1,50 @@
+name: Docker Commit
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+    tags-ignore:
+      - "*"
+
+jobs:
+  push:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node:
+          - 14.16-buster
+          - 14.16-buster-slim
+          - 14.16-stretch
+          - 14.16-stretch-slim
+
+    name: Tag Commit (node:${{ matrix.node }})
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: buildkite/puppeteer:${{ github.sha }}-${{ matrix.node }}
+          build-args: |
+            NODE_TAG=${{ matrix.node }}

--- a/.github/workflows/docker-latest-tag.yml
+++ b/.github/workflows/docker-latest-tag.yml
@@ -21,6 +21,10 @@ jobs:
     strategy:
       matrix:
         node:
+          - 12.22-buster
+          - 12.22-buster-slim
+          - 12.22-stretch
+          - 12.22-stretch-slim
           - 14.16-buster
           - 14.16-buster-slim
           - 14.16-stretch

--- a/.github/workflows/docker-latest-tag.yml
+++ b/.github/workflows/docker-latest-tag.yml
@@ -1,0 +1,52 @@
+name: Docker Latest
+
+on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - "*"
+  pull_request:
+    tags-ignore:
+      - "*"
+    branches-ignore:
+      - "*"
+
+jobs:
+  push:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node:
+          - 14.16-buster
+          - 14.16-buster-slim
+          - 14.16-stretch
+          - 14.16-stretch-slim
+
+    name: Tag Latest (node:${{ matrix.node }})
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: buildkite/puppeteer:latest-${{ matrix.node }}
+          build-args: |
+            NODE_TAG=${{ matrix.node }}

--- a/.github/workflows/docker-release-tag.yml
+++ b/.github/workflows/docker-release-tag.yml
@@ -1,0 +1,61 @@
+name: Docker Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  push:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node:
+          - 14.16-buster
+          - 14.16-buster-slim
+          - 14.16-stretch
+          - 14.16-stretch-slim
+
+    name: Tag Release (node:${{ matrix.node }})
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v2.3.0
+        with:
+          images: buildkite/puppeteer
+          tags: |
+            type=semver,pattern={{version}}-${{ matrix.node }}
+            type=semver,pattern={{major}}.{{minor}}-${{ matrix.node }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Compute GitHub tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push (node:${{ matrix.node }})
+        id: docker
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: .
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ matrix.node }}

--- a/.github/workflows/docker-release-tag.yml
+++ b/.github/workflows/docker-release-tag.yml
@@ -14,6 +14,10 @@ jobs:
     strategy:
       matrix:
         node:
+          - 12.22-buster
+          - 12.22-buster-slim
+          - 12.22-stretch
+          - 12.22-stretch-slim
           - 14.16-buster
           - 14.16-buster-slim
           - 14.16-stretch

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@
 # Initially based upon:
 # https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
 
-FROM node:14.16.0-buster-slim@sha256:ffc15488e56d99dbc9b90d496aaf47901c6a940c077bc542f675ae351e769a12
+ARG NODE_TAG=14.16.0-buster-slim@sha256:ffc15488e56d99dbc9b90d496aaf47901c6a940c077bc542f675ae351e769a12
+
+FROM node:$NODE_TAG
+
 RUN  apt-get update \
      && apt-get install -y wget gnupg ca-certificates procps libxss1 \
      && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
@@ -21,4 +24,5 @@ RUN  apt-get update \
 
 # Install Puppeteer under /node_modules so it's available system-wide
 ADD package.json package-lock.json /
+
 RUN npm install


### PR DESCRIPTION
Closes #149 The original issue stated that it needs support for Node.js 12, 13, and 14. However, it needs a bit of debate - is 13 really needed since it's not LTS?

I have added 3 new Github Actions workflows:

1. Workflow for latest tag: This occurs only on `master` branch, and the Docker image tag would be `latest-[node_version]`. For example, `latest-14.16-buster`
2. Workflow for commit: This occurs on any commit, and the Docker image tag would be `[commit_sha]-[node_version]`. For example, `4daef288cf620a87765733192d2deb72ff29d1b4-14.16-buster`. At this point I'm not sure if this is needed since it might slow down the PRs waiting for so much Docker builds
3. Workflow for release: This occurs only on release tags, and it builds two Docker image tags:
- `[version]-[node_version]`, for example: `8.0.0-14.16-buster`
- `[major].[minor]-[node_version]`, for example: `8.0-14.16-buster`. If a new tag `8.0.1` gets released, the `8.0` tag is updated with the latest `8.0.x` version.

The currently known bugs are with Dependabot - Docker workflows fail, but they just need a manual reset from the Github Actions page.

These workflows need two secrets:

- `DOCKERHUB_USERNAME` - the username for Dockerhub login for auto push
- `DOCKERHUB_TOKEN` - a token generated from [your account's security page](https://hub.docker.com/settings/security) to authenticate the user