### PR TITLE
Clarify how to use existing chrome binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ See the list of [Docker Hub tags](https://hub.docker.com/r/buildkite/puppeteer/t
 
 See the [example directory](example) for a complete Docker Compose example, showing how to run Puppeteer against a linked Docker Compose web service.
 
+## Usage
+
+When installing dependencies, Chrome binary retrieval can be skipped
+
+```
+PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm i
+```
+
+The global Chrome binary will need to be specified
+
+```
+PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome node index.js
+```
+
+
 ## Releasing
 
 1. Create a new release on GitHub. The image is tagged with the same version as Puppeteer.


### PR DESCRIPTION
I suspect a lot of projects that use this image include `puppeteer` in the project `package.json`.

It isn't immediately obvious how to avoid fetching the chrome binary, or where the chrome binary exists in this particular image.