### PR TITLE
Add deprecation notice in advance of archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Docker Puppeteer
 
+## Deprecated
+
+> buildkite/docker-puppeteer has been deprecated and no longer maintained.
+
+## Description
+
 A Node + Puppeteer base image for running Puppeteer scripts. Add your own tools (such as Jest, Mocha, etc), link services you want to test via Docker Compose, and run your Puppeteer scripts with a headless Chromium.
 
 ## Versions

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Deprecated
 
-> buildkite/docker-puppeteer has been deprecated and no longer maintained.
+> We no longer use this image at Buildkite, and this repository and Docker image are no longer maintained. Please see [Puppeteer’s troubleshooting doc](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md) for the latest information on running Puppeteer in Docker, or alternatively you can find [other pre-made images around GitHub](https://github.com/search?q=docker+puppeteer).
 
 ## Description
 


### PR DESCRIPTION
As we no longer use this image at Buildkite, this repository will no longer be maintained and no further updates will be made. We'll soon be archiving the repository, and this PR updates the `README` to let people know this and provide some further suggestions to keep using puppeteer in Docker.